### PR TITLE
Update lib/ruby-paypal/credit_card_checks.rb

### DIFF
--- a/lib/ruby-paypal/credit_card_checks.rb
+++ b/lib/ruby-paypal/credit_card_checks.rb
@@ -35,7 +35,7 @@ module CreditCardChecks
       when "VISA"
         validity = true if (number.length == 16 or number.length = 13) and number[0,1] == "4"
       when "MASTERCARD"
-        validity = true if (number.length == 16) and (52..55).include?(number[0,2].to_i)
+        validity = true if (number.length == 16) and (51..55).include?(number[0,2].to_i)
       when "AMEX"
         validity = true if (number.length == 16) and ['34', '37'].include?(number[0,2])
       when "DISCOVER"


### PR DESCRIPTION
On http://en.wikipedia.org/wiki/Credit_card_number you can see that MasterCard can start from 51 to 55. Updated validations rule.
